### PR TITLE
Ensure that the filelock is unlocked *after* the container is gone

### DIFF
--- a/src/pytest_container/plugin.py
+++ b/src/pytest_container/plugin.py
@@ -113,8 +113,6 @@ def _auto_container_fixture(
     except RuntimeError as exc:
         raise exc
     finally:
-        if launch_data.singleton:
-            release_lock()
         if container_id is not None:
             _logger.debug(
                 "Removing container %s via %s",
@@ -124,6 +122,8 @@ def _auto_container_fixture(
             check_output(
                 [container_runtime.runner_binary, "rm", "-f", container_id]
             )
+        if launch_data.singleton:
+            release_lock()
 
 
 auto_container = pytest.fixture(scope="session")(_auto_container_fixture)


### PR DESCRIPTION
Beforehands there was a short window of opportunity for race conditions: the
filelock would get unlocked and afterwards the container would get
destroyed. However during this short time period a new instance of the same
container image could launch, resulting in an error, e.g. by binding to the same
port.
To be correct, we must first destroy the container and then unlock the lock.

This fixes issues like: https://github.com/SUSE/BCI-tests/issues/112