### PR TITLE
Add helper property: OciRuntimeBase.version

### DIFF
--- a/source/usage.rst
+++ b/source/usage.rst
@@ -103,6 +103,29 @@ A Container defined in this way can be used like any other Container
 instance.
 
 
+Container Runtime version
+-------------------------
+
+Sometimes it is necessary to implement tests differently depending on the
+version of the container runtime. The subclasses of
+:py:class:`~pytest_container.runtime.OciRuntimeBase` have the property
+:py:attr:`~pytest_container.runtime.OciRuntimeBase.version` which returns the
+runtime version of the respective runtime, e.g. of :command:`podman`.
+
+The returned object is an instance of
+:py:class:`~pytest_container.runtime.Version` and supports comparison to for
+instance skip certain tests:
+
+.. code-block:: python
+
+   @pytest.mark.skipif(
+       get_selected_runtime().version < Version(4, 0),
+       reason="This check requires at least Podman 4.0",
+   )
+   def test_modern_podman_feature(auto_container):
+       # test $new_feature here
+
+
 Copying files into containers
 -----------------------------
 

--- a/src/pytest_container/__init__.py
+++ b/src/pytest_container/__init__.py
@@ -14,3 +14,4 @@ from .runtime import DockerRuntime
 from .runtime import get_selected_runtime
 from .runtime import OciRuntimeBase
 from .runtime import PodmanRuntime
+from .runtime import Version

--- a/src/pytest_container/build.py
+++ b/src/pytest_container/build.py
@@ -175,7 +175,7 @@ class MultiStageBuild:
                 )
 
         dockerfile_dest = tmp_dir / "Dockerfile"
-        with open(dockerfile_dest, "w") as containerfile:
+        with open(dockerfile_dest, "w", encoding="utf-8") as containerfile:
             _logger.debug(
                 "Writing the following dockerfile into %s: %s",
                 dockerfile_dest,

--- a/src/pytest_container/container.py
+++ b/src/pytest_container/container.py
@@ -95,6 +95,10 @@ class ContainerBase:
 
     @property
     def local_image(self) -> bool:
+        """Returns true if this image has been build locally and has not been
+        pulled from a registry.
+
+        """
         return self._is_local
 
     @property

--- a/src/pytest_container/container.py
+++ b/src/pytest_container/container.py
@@ -86,7 +86,7 @@ class ContainerBase:
                 f"A custom entry point has been provided ({self.custom_entry_point}) with default_entry_point being set to True"
             )
 
-        if self.url.split(":")[0] == "containers-storage":
+        if self.url.split(":", maxsplit=1)[0] == "containers-storage":
             self._is_local = True
             self.url = self.url.replace("containers-storage:", "")
 

--- a/src/pytest_container/runtime.py
+++ b/src/pytest_container/runtime.py
@@ -1,4 +1,5 @@
 import enum
+import re
 from abc import ABC
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -6,7 +7,9 @@ from dataclasses import field
 from os import getenv
 from subprocess import check_output
 from typing import Any
+from typing import Callable
 from typing import List
+from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union
 
@@ -33,12 +36,90 @@ class ToParamMixin:
 
 
 @dataclass(frozen=True)
+class Version:
+    """Representation of a version of the form ``$major.$minor.$patch`` and an
+    optional build string.
+
+    This class supports basic comparison, e.g.:
+
+    >>> Version(1, 0) > Version(0, 1)
+    True
+    >>> Version(1, 0) == Version(1, 0, 0)
+    True
+    >>> Version(5, 2, 6, "foobar") == Version(5, 2, 6)
+    False
+
+    Additionally you can also pretty print it:
+
+    >>> Version(0, 6)
+    0.6
+    >>> Version(0, 6, 1)
+    0.6.1
+    >>> Version(0, 6, 1, "asdf")
+    0.6.1 build asdf
+    """
+
+    major: int = 0
+    minor: int = 0
+    patch: Optional[int] = None
+    build: str = ""
+
+    def __str__(self) -> str:
+        return (
+            f"{self.major}.{self.minor}{('.' + str(self.patch)) if self.patch else ''}"
+            + (f" build {self.build}" if self.build else "")
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and (self.patch or 0) == (other.patch or 0)
+            and self.build == other.build
+        )
+
+    @staticmethod
+    def __generate_cmp(
+        cmp_func: Callable[[int, int], bool]
+    ) -> Callable[["Version", Any], bool]:
+        def cmp(self: Version, other: Any) -> bool:
+            if not isinstance(other, Version):
+                return NotImplemented
+
+            if cmp_func(self.major, other.major):
+                return True
+            if cmp_func(self.minor, other.minor):
+                return True
+            if cmp_func(self.patch or 0, other.patch or 0):
+                return True
+
+            return False
+
+        return cmp
+
+    def __lt__(self, other: Any) -> bool:
+        return Version.__generate_cmp(lambda m, n: m < n)(self, other)
+
+    def __le__(self, other: Any) -> bool:
+        return Version.__generate_cmp(lambda m, n: m <= n)(self, other)
+
+    def __ge__(self, other: Any) -> bool:
+        return Version.__generate_cmp(lambda m, n: m >= n)(self, other)
+
+    def __gt__(self, other: Any) -> bool:
+        return Version.__generate_cmp(lambda m, n: m > n)(self, other)
+
+
+@dataclass(frozen=True)
 class _OciRuntimeBase:
     #: command that builds the Dockerfile in the current working directory
     build_command: List[str] = field(default_factory=list)
     #: the "main" binary of this runtime, e.g. podman or docker
     runner_binary: str = ""
     _runtime_functional: bool = False
+    _version: Version = field(default_factory=Version)
 
 
 @enum.unique
@@ -80,10 +161,16 @@ class OciRuntimeABC(ABC):
         health.
 
         """
-        pass
+
+    @property
+    @abstractmethod
+    def version(self) -> Version:
+        """The version of the container runtime."""
 
 
 class OciRuntimeBase(_OciRuntimeBase, OciRuntimeABC, ToParamMixin):
+    """Base class of the Container Runtimes."""
+
     def __post_init__(self) -> None:
         if not self.build_command or not self.runner_binary:
             raise ValueError(
@@ -132,8 +219,32 @@ class OciRuntimeBase(_OciRuntimeBase, OciRuntimeABC, ToParamMixin):
     def __str__(self) -> str:
         return self.__class__.__name__
 
+    @property
+    def version(self) -> Version:
+        """Returns the container runtime's version"""
+        return self._version
+
 
 LOCALHOST = testinfra.host.get_host("local://")
+
+
+def _get_podman_version(version_stdout: str) -> Version:
+    matches = re.match(
+        r"podman version (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?",
+        version_stdout,
+        flags=re.IGNORECASE,
+    )
+    if not matches:
+        raise RuntimeError(
+            f"Could not decode the podman version from {version_stdout}"
+        )
+
+    patch = matches.group("patch")
+    return Version(
+        major=int(matches.group("major")),
+        minor=int(matches.group("minor")),
+        patch=int(patch) if patch else 0,
+    )
 
 
 class PodmanRuntime(OciRuntimeBase):
@@ -145,6 +256,10 @@ class PodmanRuntime(OciRuntimeBase):
     _runtime_functional = (
         LOCALHOST.run("podman ps").succeeded
         and LOCALHOST.run("buildah").succeeded
+    )
+
+    _version = _get_podman_version(
+        LOCALHOST.run_expect([0], "podman --version").stdout
     )
 
     @staticmethod
@@ -189,9 +304,33 @@ class PodmanRuntime(OciRuntimeBase):
         return ContainerHealth.UNHEALTHY
 
 
+def _get_docker_version(version_stdout: str) -> Version:
+    matches = re.match(
+        r"docker version (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+)(\S+)?)?,"
+        r" build (?P<build>\S+)",
+        version_stdout,
+        flags=re.IGNORECASE,
+    )
+    if not matches:
+        raise RuntimeError(
+            f"Could not decode the docker version from {version_stdout}"
+        )
+    patch = matches.group("patch")
+    return Version(
+        major=int(matches.group("major")),
+        minor=int(matches.group("minor")),
+        patch=int(patch) if patch else 0,
+        build=matches.group("build"),
+    )
+
+
 class DockerRuntime(OciRuntimeBase):
     """The container runtime using :command:`docker` for building and running
     containers."""
+
+    _version = _get_docker_version(
+        LOCALHOST.run_expect([0], "docker --version").stdout
+    )
 
     _runtime_functional = LOCALHOST.run("docker ps").succeeded
 

--- a/src/pytest_container/runtime.py
+++ b/src/pytest_container/runtime.py
@@ -234,7 +234,7 @@ class DockerRuntime(OciRuntimeBase):
         stdout = res.stdout.strip()
         if stdout == "healthy":
             return ContainerHealth.HEALTHY
-        elif stdout == "starting":
+        if stdout == "starting":
             return ContainerHealth.STARTING
         return ContainerHealth.UNHEALTHY
 

--- a/tests/base/test_version.py
+++ b/tests/base/test_version.py
@@ -1,0 +1,124 @@
+"""Unit tests of the Version class"""
+from pytest_container import Version
+from pytest_container.runtime import _get_docker_version
+from pytest_container.runtime import _get_podman_version
+
+import pytest
+
+# pragma pylint: disable=missing-function-docstring
+
+
+@pytest.mark.parametrize(
+    "ver1,ver2",
+    [
+        (Version(1, 0, 2), Version(1, 0, 2)),
+        (Version(2, 0), Version(2, 0, 0)),
+    ],
+)
+def test_version_eq(ver1: Version, ver2: Version):
+    assert ver1 == ver2
+
+
+def test_incompatible_types_eq():
+    assert Version(1, 2) != 3
+
+
+def test_incompatible_types_cmp():
+    with pytest.raises(TypeError) as ctx:
+        Version(1, 2) < 3
+
+    assert "'<' not supported between instances of 'Version' and 'int'" in str(
+        ctx.value
+    )
+
+
+@pytest.mark.parametrize(
+    "ver1,ver2",
+    [
+        (Version(1, 0, 2), Version(1, 0, 1)),
+        (Version(2, 0, 1), Version(1, 0, 1)),
+        (Version(1, 5, 1), Version(1, 0, 1)),
+        (Version(1, 0, 1), Version(1, 0, 1, "foobar")),
+    ],
+)
+def test_version_ne(ver1: Version, ver2: Version):
+    assert ver1 != ver2
+
+
+@pytest.mark.parametrize(
+    "ver,stringified",
+    [
+        (Version(1, 2), "1.2"),
+        (Version(1, 2, 5), "1.2.5"),
+        (Version(1, 2, 5, "sdf"), "1.2.5 build sdf"),
+    ],
+)
+def test_version_str(ver: Version, stringified):
+    assert str(ver) == stringified
+
+
+@pytest.mark.parametrize(
+    "larger,smaller",
+    [
+        (Version(1, 2, 3), Version(1, 2, 2)),
+        (Version(1, 2, 3), Version(1, 1, 3)),
+        (Version(1, 2, 3), Version(0, 2, 3)),
+    ],
+)
+def test_version_ge_gt(larger: Version, smaller: Version):
+    assert larger > smaller
+    assert larger >= smaller
+    # pragma pylint: disable=comparison-with-itself
+    assert larger >= larger
+    assert smaller >= smaller
+
+
+@pytest.mark.parametrize(
+    "larger,smaller",
+    [
+        (Version(1, 2, 3), Version(1, 2, 2)),
+        (Version(1, 2, 3), Version(1, 1, 3)),
+        (Version(1, 2, 3), Version(0, 2, 3)),
+    ],
+)
+def test_version_le_lt(larger: Version, smaller: Version):
+    assert smaller < larger
+    assert smaller <= larger
+    # pragma pylint: disable=comparison-with-itself
+    assert larger <= larger
+    assert smaller <= smaller
+
+
+@pytest.mark.parametrize(
+    "stdout,ver",
+    [
+        ("Docker version 1.12.6, build 78d1802", Version(1, 12, 6, "78d1802")),
+        (
+            "Docker version 20.10.12-ce, build 459d0dfbbb51",
+            Version(20, 10, 12, "459d0dfbbb51"),
+        ),
+        (
+            "Docker version 20.10.16, build aa7e414",
+            Version(20, 10, 16, "aa7e414"),
+        ),
+        (
+            "Docker version 1.13.1, build 7d71120/1.13.1",
+            Version(1, 13, 1, "7d71120/1.13.1"),
+        ),
+    ],
+)
+def test_docker_version_extract(stdout: str, ver: Version):
+    assert _get_docker_version(stdout) == ver
+
+
+@pytest.mark.parametrize(
+    "stdout,ver",
+    [
+        ("podman version 3.0.1", Version(3, 0, 1)),
+        ("podman version 3.4.4", Version(3, 4, 4)),
+        ("podman version 1.6.4", Version(1, 6, 4)),
+        ("podman version 4.0.2", Version(4, 0, 2)),
+    ],
+)
+def test_podman_version_extract(stdout: str, ver: Version):
+    assert _get_podman_version(stdout) == ver

--- a/tox.ini
+++ b/tox.ini
@@ -18,4 +18,4 @@ commands = sphinx-build -M html source build -W []
 [testenv:lint]
 commands =
     mypy src/pytest_container
-    pylint --fail-under 8.45 src/pytest_container tests/
+    pylint --fail-under 8.75 src/pytest_container tests/


### PR DESCRIPTION
This exposes the version of the container runtime to the user and allows for simple skipping of tests.