### PR TITLE
Reset the entrypoint properly when custom_entrypoint is used

### DIFF
--- a/tests/images.py
+++ b/tests/images.py
@@ -32,6 +32,14 @@ HEALTHCHECK --retries=1 --interval=1s --timeout=1s CMD false
 """,
 )
 
+CMDLINE_APP_CONTAINER = DerivedContainer(
+    base=LEAP,
+    containerfile="""
+ENTRYPOINT ["/usr/bin/id"]
+CMD ["--help"]
+""",
+)
+
 LEAP_WITH_MAN = DerivedContainer(
     base=LEAP_URL,
     containerfile="RUN zypper -n in man",

--- a/tests/images.py
+++ b/tests/images.py
@@ -34,6 +34,7 @@ HEALTHCHECK --retries=1 --interval=1s --timeout=1s CMD false
 
 CMDLINE_APP_CONTAINER = DerivedContainer(
     base=LEAP,
+    custom_entry_point="/bin/sh",
     containerfile="""
 ENTRYPOINT ["/usr/bin/id"]
 CMD ["--help"]

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from .images import CMDLINE_APP_CONTAINER
 from .images import CONTAINER_THAT_FAILS_TO_LAUNCH
 from .images import LEAP
 from .test_volumes import LEAP_WITH_BIND_MOUNT_AND_VOLUME
@@ -210,6 +211,22 @@ def test_launcher_does_not_override_stopsignal_for_entrypoint(
 
     """
     assert container.inspect.config.stop_signal in (9, "SIGKILL")
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        CMDLINE_APP_CONTAINER,
+    ],
+    indirect=True,
+)
+def test_launcher_does_can_check_binaries_with_entrypoint(
+    container: ContainerData,
+) -> None:
+    """Check that the we can check for installed binaries even if the container
+    has an entrypoint specified that is not a shell and terminates immediately.
+    """
+    assert container.connection.exists("bash")
 
 
 def test_derived_container_pulls_base(


### PR DESCRIPTION
the entrypoint needs to be set via --entrypoint not as a command at the end. the command are just the additional parameters when entrypoint is being configured.