### PR TITLE
Improve compatibility with docker 24.0.x

### DIFF
--- a/pytest_container/runtime.py
+++ b/pytest_container/runtime.py
@@ -546,7 +546,13 @@ class DockerRuntime(OciRuntimeBase):
 
     def __init__(self) -> None:
         super().__init__(
-            build_command=["docker", "build", "--force-rm"],
+            build_command=[
+                "env",
+                "DOCKER_BUILDKIT=0",
+                "docker",
+                "build",
+                "--force-rm",
+            ],
             runner_binary="docker",
             _runtime_functional=self._runtime_functional,
         )

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -133,11 +133,11 @@ def test_launcher_cleanes_up_volumes_from_image(
 
         vol_name = mounts[0].name
     assert (
-        "Error:"
+        "no such volume"
         in host.run_expect(
             [1, 125],
             f"{container_runtime.runner_binary} volume inspect {vol_name}",
-        ).stderr
+        ).stderr.lower()
     )
 
 


### PR DESCRIPTION
The error message is now "Error from daemon: .... no such volume". So the colon after "Error" is now missing. Switch to a more specific part of the error message that appears to be more common across versions and variants
