### PR TITLE
DerivedContainer inhertis container_id, url from the base on prepare

### DIFF
--- a/pytest_container/container.py
+++ b/pytest_container/container.py
@@ -694,7 +694,8 @@ class DerivedContainer(ContainerBase, ContainerBaseABC):
         # do not build containers without a containerfile and where no build
         # tags are added
         if not self.containerfile and not self.add_build_tags:
-            self.container_id = str(self.get_base())
+            base = self.get_base()
+            self.container_id, self.url = base.container_id, base.url
             return
 
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -51,7 +51,9 @@ def test_lockfile_path(pytestconfig: pytest.Config) -> None:
     :py:attr:`~pytest_container.ContainerBase.container_id` set.
 
     """
-    cont = DerivedContainer(base=images.OPENSUSE_BUSYBOX_URL, containerfile="")
+    cont = DerivedContainer(
+        base=images.OPENSUSE_BUSYBOX_URL, containerfile="ENV BAZ=1"
+    )
     original_lock_fname = cont.filelock_filename
 
     cont.prepare_container(pytestconfig.rootpath)
@@ -67,3 +69,9 @@ def test_lockfile_unique() -> None:
         base=images.OPENSUSE_BUSYBOX_URL, containerfile="ENV foobar=1"
     )
     assert cont1.filelock_filename != cont2.filelock_filename
+
+
+def test_derived_container_build_tag(pytestconfig: pytest.Config) -> None:
+    cont = DerivedContainer(base=images.OPENSUSE_BUSYBOX_URL)
+    cont.prepare_container(pytestconfig.rootpath)
+    assert cont._build_tag == images.OPENSUSE_BUSYBOX_URL

--- a/tests/test_container_build.py
+++ b/tests/test_container_build.py
@@ -131,7 +131,8 @@ def test_container_without_containerfile_and_without_tags_not_rebuild(
         and not container.container.add_build_tags
     )
     assert container.container.get_base() == LEAP
-    assert container.container.container_id == LEAP.url
+    assert container.container.url == LEAP.url
+    assert container.container._build_tag == LEAP.url
 
 
 @pytest.mark.parametrize("container", [LEAP_WITH_TAG], indirect=True)


### PR DESCRIPTION
If the base is just a container image, then we want the url property to be set instead of the `container_id` as otherwise the `_build_tag` property will be `pytest_container:$url`