### PR TITLE
Replace container_from_pytest_param with container_and_marks_from_pytest_param

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Next Release
 
 Breaking changes:
 
+- deprecate the function ``pytest_container.container_from_pytest_param``,
+  please use
+  :py:func:`~pytest_container.container.container_and_marks_from_pytest_param`
+  instead.
+
 
 Improvements and new features:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,6 +207,20 @@ files = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+optional = false
+python-versions = "*"
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
 name = "dill"
 version = "0.3.4"
 description = "serialize all of python"
@@ -1139,4 +1153,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "df615dc6120ae8b3be7ef9c11868fe483c0a7f6600a8e5c4f3963838427d4e5c"
+content-hash = "1254a784b736e00c16cf0e7d3d919dd0c5e04ccf3bfa3bd5e6d9ce8153357442"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dataclasses = { version = ">=0.8", python = "< 3.7" }
 typing-extensions = { version = ">=3.0", markers="python_version < '3.8'" }
 cached-property = { version = "^1.5", markers="python_version < '3.8'" }
 filelock = "^3.4"
+deprecation = "^2.1"
 
 [tool.poetry.dev-dependencies]
 black = ">=21.9b0"
@@ -57,5 +58,5 @@ line-length = 79
 strict = true
 
 [[tool.mypy.overrides]]
-module = "testinfra"
+module = "testinfra,deprecation"
 ignore_missing_imports = true

--- a/pytest_container/__init__.py
+++ b/pytest_container/__init__.py
@@ -5,6 +5,7 @@ images or software in container images with pytest.
 from .build import GitRepositoryBuild
 from .build import MultiStageBuild
 from .container import Container
+from .container import container_and_marks_from_pytest_param
 from .container import container_from_pytest_param
 from .container import container_to_pytest_param
 from .container import DerivedContainer

--- a/pytest_container/build.py
+++ b/pytest_container/build.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 from _pytest.config import Config
 from _pytest.mark.structures import ParameterSet
 from pytest_container.container import Container
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import DerivedContainer
 from pytest_container.logging import _logger
 from pytest_container.runtime import OciRuntimeBase
@@ -158,7 +158,9 @@ class MultiStageBuild:
             **{
                 k: v
                 if isinstance(v, str)
-                else str(container_from_pytest_param(v)._build_tag)
+                else str(
+                    container_and_marks_from_pytest_param(v)[0]._build_tag
+                )
                 for k, v in self.containers.items()
             }
         )
@@ -178,9 +180,9 @@ class MultiStageBuild:
         _logger.debug("Preparing multistage build")
         for _, container in self.containers.items():
             if not isinstance(container, str):
-                container_from_pytest_param(container).prepare_container(
-                    rootdir, extra_build_args
-                )
+                container_and_marks_from_pytest_param(container)[
+                    0
+                ].prepare_container(rootdir, extra_build_args)
 
         dockerfile_dest = tmp_path / "Dockerfile"
         with open(dockerfile_dest, "w", encoding="utf-8") as containerfile:

--- a/pytest_container/plugin.py
+++ b/pytest_container/plugin.py
@@ -8,7 +8,7 @@ from subprocess import run
 from typing import Callable
 from typing import Generator
 
-from pytest_container.container import container_from_pytest_param
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.container import ContainerLauncher
 from pytest_container.helpers import get_extra_build_args
@@ -76,12 +76,12 @@ def _create_auto_container_fixture(
         pytest_generate_tests.
         """
 
-        launch_data = container_from_pytest_param(request.param)
-        _logger.debug("Requesting the container %s", str(launch_data))
+        container, _ = container_and_marks_from_pytest_param(request.param)
+        _logger.debug("Requesting the container %s", str(container))
 
-        if scope == "session" and launch_data.singleton:
+        if scope == "session" and container.singleton:
             raise RuntimeError(
-                f"A singleton container ({launch_data}) cannot be used in a session level fixture"
+                f"A singleton container ({container}) cannot be used in a session level fixture"
             )
 
         add_labels = [
@@ -100,7 +100,7 @@ def _create_auto_container_fixture(
             pass
 
         with ContainerLauncher(
-            container=launch_data,
+            container=container,
             container_runtime=container_runtime,
             rootdir=pytestconfig.rootpath,
             extra_build_args=get_extra_build_args(pytestconfig),

--- a/tests/test_pytest_param.py
+++ b/tests/test_pytest_param.py
@@ -10,6 +10,7 @@ from pytest_container import DerivedContainer
 from pytest_container import get_extra_build_args
 from pytest_container import MultiStageBuild
 from pytest_container import OciRuntimeBase
+from pytest_container.container import container_and_marks_from_pytest_param
 from pytest_container.container import ContainerData
 from pytest_container.pod import Pod
 from pytest_container.pod import pod_from_pytest_param
@@ -113,6 +114,33 @@ def test_container_from_pytest_param() -> None:
 
     with pytest.raises(ValueError) as val_err_ctx:
         container_from_pytest_param(pytest.param(16, 45))
+    assert "Invalid pytest.param values" in str(val_err_ctx.value)
+    assert "(16, 45)" in str(val_err_ctx.value)
+
+
+def test_container_and_marks_from_pytest_param() -> None:
+    cont, marks = container_and_marks_from_pytest_param(
+        container_to_pytest_param(LEAP)
+    )
+    assert cont == LEAP and not marks
+
+    cont, marks = container_and_marks_from_pytest_param(
+        pytest.param(LEAP, 1, "a")
+    )
+    assert cont == LEAP and not marks
+
+    assert container_and_marks_from_pytest_param(LEAP) == (LEAP, None)
+
+    derived = DerivedContainer(base=LEAP, containerfile="ENV foo=bar")
+    cont, marks = container_and_marks_from_pytest_param(
+        container_to_pytest_param(derived)
+    )
+    assert cont == derived and not marks
+
+    assert container_and_marks_from_pytest_param(derived) == (derived, None)
+
+    with pytest.raises(ValueError) as val_err_ctx:
+        container_and_marks_from_pytest_param(pytest.param(16, 45))
     assert "Invalid pytest.param values" in str(val_err_ctx.value)
     assert "(16, 45)" in str(val_err_ctx.value)
 


### PR DESCRIPTION
- deprecate `container_from_pytest_param`
- replace it internally with `container_and_marks_from_pytest_param`

`container_and_marks_from_pytest_param` is more flexible as it encourages users to not forget about marks when creating new containers from `pytest.param` instances.