### PR TITLE
Allow port forwarding from any host IP

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,12 @@ Breaking changes:
 Improvements and new features:
 
 
+- Add property :py:attr:`~pytest_container.inspect.PortForwarding.bind_ip`
+  to support binding to arbitrary IP addresses.
+- Fix :py:attr:`~pytest_container.inspect.PortForwarding.host_port` being
+  ignored when picking the host port
+
+
 Documentation:
 
 

--- a/pytest_container/container.py
+++ b/pytest_container/container.py
@@ -93,12 +93,16 @@ def create_host_port_port_forward(
     sockets: List[socket.socket] = []
 
     for port in port_forwards:
+        if socket.has_ipv6 and (":" in port.bind_ip or not port.bind_ip):
+            family = socket.AF_INET6
+        else:
+            family = socket.AF_INET
 
         sock = socket.socket(
-            family=socket.AF_INET6 if socket.has_ipv6 else socket.AF_INET,
+            family=family,
             type=port.protocol.SOCK_CONST,
         )
-        sock.bind(("", 0))
+        sock.bind((port.bind_ip, max(0, port.host_port)))
 
         port_num: int = sock.getsockname()[1]
 
@@ -107,6 +111,7 @@ def create_host_port_port_forward(
                 container_port=port.container_port,
                 protocol=port.protocol,
                 host_port=port_num,
+                bind_ip=port.bind_ip,
             )
         )
         sockets.append(sock)

--- a/pytest_container/inspect.py
+++ b/pytest_container/inspect.py
@@ -68,15 +68,30 @@ class PortForwarding:
     #: so there's no need for the user to modify it
     host_port: int = -1
 
+    #: The IP address to which to bind. By default, it will be '::' (all addresses).
+    bind_ip: str = ""
+
     @property
     def forward_cli_args(self) -> List[str]:
         """Returns a list of command line arguments for the container launch
         command to automatically expose this port forwarding.
 
         """
+
+        if self.bind_ip:
+            # If it contains a colon, it must be an IPv6 address and thus must
+            # be wrapped in brackets for the launch command
+            if ":" in self.bind_ip:
+                bind_ip = f"[{self.bind_ip}]:"
+            else:
+                bind_ip = self.bind_ip + ":"
+        else:
+            bind_ip = ""
+
         return [
             "-p",
-            ("" if self.host_port == -1 else f"{self.host_port}:")
+            bind_ip
+            + ("" if self.host_port == -1 else f"{self.host_port}:")
             + f"{self.container_port}/{self.protocol}",
         ]
 

--- a/tests/test_port_forwarding.py
+++ b/tests/test_port_forwarding.py
@@ -79,6 +79,16 @@ if _curl_version >= Version(major=7, minor=71, patch=0):
         ),
         (
             PortForwarding(
+                container_port=80, host_port=8080, bind_ip="127.0.0.1"
+            ),
+            ["-p", "127.0.0.1:8080:80/tcp"],
+        ),
+        (
+            PortForwarding(container_port=80, host_port=8080, bind_ip="::1"),
+            ["-p", "[::1]:8080:80/tcp"],
+        ),
+        (
+            PortForwarding(
                 container_port=53, host_port=5053, protocol=NetworkProtocol.UDP
             ),
             ["-p", "5053:53/udp"],


### PR DESCRIPTION
See #169. With this commit we are able to define the bind IP address when using port forwarding, which will be passed to `--publish` of podman-run.

---

Note: I did not quite understand your logic `create_host_port_port_forward()`. In the returned `PortForward` objects, `host_port` is always random. I believe this to be a bug, so please check my change [here](https://github.com/AdrianVollmer/pytest_container/blob/allow_bind_ip/pytest_container/container.py#L109) if it makes sense. I can split it into a separate PR if you want.