### PR TITLE
Changing the CONTAINER_RUNTIME to CONTAINER_RUNTIMES

### DIFF
--- a/pytest_container/runtime.py
+++ b/pytest_container/runtime.py
@@ -614,14 +614,14 @@ def get_selected_runtime() -> OciRuntimeBase:
 
     It defaults to podman and selects docker if podman & buildah are not
     present. If podman and docker are both present, then docker is returned if
-    the environment variable `CONTAINER_RUNTIME` is set to `docker`.
+    the environment variable `CONTAINER_RUNTIMES` is set to `docker`.
 
     If neither docker nor podman are available, then a ValueError is raised.
     """
     podman_exists = LOCALHOST.exists("podman") and LOCALHOST.exists("buildah")
     docker_exists = LOCALHOST.exists("docker")
 
-    runtime_choice = getenv("CONTAINER_RUNTIME", "podman").lower()
+    runtime_choice = getenv("CONTAINER_RUNTIMES", "podman").lower()
     if runtime_choice not in ("podman", "docker"):
         raise ValueError(f"Invalid CONTAINER_RUNTIME {runtime_choice}")
 


### PR DESCRIPTION
Related PR:  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/18145 
Many failures when the runtime is set to docker: [bci-base_15.5](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP5&build=36.5.54_sles15-image&groupid=475), [bci-init_15.5](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP5&build=10.33_init-image&groupid=475), [bci-minimal_15.4](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP4&build=24.13_minimal-image&groupid=443), [python_3.11](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP5&build=12.27_python-3.11-image&groupid=444), [git](https://openqa.suse.de/tests/overview?result=failed&result=incomplete&result=timeout_exceeded&distri=sle&version=15-SP5&build=4.14_git-image&groupid=445) ...