### PR TITLE
Make infratest optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Breaking changes:
 - Change addition of SELinux flags to volumes: SELinux flags are only added if
   :py:attr:`~pytest_container.container.ContainerVolumeBase.flags` is ``None``.
 
+- Package does not depend on ``pytest-testinfra`` by default anymore. If you
+  want to use the :py:attr:`~pytest_container.container.ContainerData.connection``,
+  you have to add the ``[testinfra]`` extra to your ``pytest-containers`` dependency.
+
 Improvements and new features:
 
 - Add the function
@@ -28,6 +32,8 @@ Documentation:
 
 
 Internal changes:
+
+- The test suite now runs on OS X.
 
 
 0.4.2 (10 April 2024)

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,7 @@ Find the latest documentation on `dcermak.github.io/pytest_container
 <https://dcermak.github.io/pytest_container/>`_.
 
 ``pytest_container`` is a `pytest <https://pytest.org>`_ plugin
-to test container images via pytest fixtures and `testinfra
-<https://testinfra.readthedocs.io/en/latest/>`_. It takes care of all the boring
+to test container images via pytest fixtures. It takes care of all the boring
 tasks, like spinning up containers, finding free ports and cleaning up after
 tests, and allows you to focus on implementing the actual tests.
 
@@ -49,16 +48,24 @@ instantiating a ``Container`` and parametrizing a test function with the
 
    @pytest.mark.parametrize("container", [TW], indirect=["container"])
    def test_etc_os_release_present(container: ContainerData):
-       assert container.connection.file("/etc/os-release").exists
+        assert container.remote.check_output("test -f /etc/os-release")
 
 
 The fixture automatically pulls and spins up the container, stops it and removes
 it after the test is completed. Your test function receives an instance of
-``ContainerData`` with the ``ContainerData.connection`` attribute. The
-``ContainerData.connection`` attribute is a `testinfra
-<https://testinfra.readthedocs.io/en/latest/>`_ connection object. It can be
-used to run basic tests inside the container itself. For example, you can check
-whether files are present, packages are installed, etc.
+``ContainerData``.
+
+
+Testinfa
+--------
+
+You can optionally use the `testinfra <https://testinfra.readthedocs.io/en/latest/>`_
+library to interact with the container.  You need to install the ``pytest-testinfra``
+package directly or use the ``[testinfra]`` extra on this package.
+
+If test infra is installed, the ``ContainerData`` instance will have a
+``connection`` attribute that is an instance of ``testinfra.Connection``. Otherwise
+this attribute will be ``None``.
 
 
 Use cases

--- a/poetry.lock
+++ b/poetry.lock
@@ -315,6 +315,17 @@ files = [
 ]
 
 [[package]]
+name = "ifaddr"
+version = "0.2.0"
+description = "Cross-platform network interface and IP address enumeration library"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"},
+    {file = "ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4"},
+]
+
+[[package]]
 name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
@@ -789,7 +800,7 @@ pytest = ">=5.3"
 name = "pytest-testinfra"
 version = "6.8.0"
 description = "Test infrastructures"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "pytest-testinfra-6.8.0.tar.gz", hash = "sha256:07c8c2c472aca7d83099ebc5f850d383721cd654b66c60ffbb145e45e584ff99"},
@@ -809,7 +820,7 @@ winrm = ["pywinrm"]
 name = "pytest-testinfra"
 version = "7.0.0"
 description = "Test infrastructures"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "pytest-testinfra-7.0.0.tar.gz", hash = "sha256:38c2ce2df4e25f685636c7db9ac15083a7cf3e4a8a997d5fa654e8a7bedeadce"},
@@ -829,7 +840,7 @@ winrm = ["pywinrm"]
 name = "pytest-testinfra"
 version = "8.1.0"
 description = "Test infrastructures"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pytest-testinfra-8.1.0.tar.gz", hash = "sha256:9b40828b58fb7ac2bff29cc1465934adf434f10dd5a108f60535dee52660a63d"},
@@ -1269,7 +1280,10 @@ files = [
 docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy"]
 
+[extras]
+testinfra = ["pytest-testinfra", "pytest-testinfra", "pytest-testinfra"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.6.2,<4.0"
-content-hash = "102929861937499368a9f2c3c71533af949816aa8da41fa845dd51ed97af46b8"
+content-hash = "50e459665bbdf6d76e704771f89ac951ff19a43eddb7c89456add7583e0c0635"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,16 +28,21 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.6.2,<4.0"
 pytest = ">= 3.10"
-pytest-testinfra = [
-    { version = ">=6.4.0", python = "< 3.7" },
-    { version = ">=7.0", python = ">= 3.7,< 3.8" },
-    { version = ">=8.0", python = ">= 3.8" }
-]
 dataclasses = { version = ">=0.8", python = "< 3.7" }
 typing-extensions = { version = ">=3.0", markers="python_version < '3.8'" }
 cached-property = { version = "^1.5", markers="python_version < '3.8'" }
 filelock = "^3.4"
 deprecation = "^2.1"
+
+pytest-testinfra = [
+    { version = ">=6.4.0", python = "< 3.7", optional = true },
+    { version = ">=7.0", python = ">= 3.7,< 3.8", optional = true },
+    { version = ">=8.0", python = ">= 3.8", optional = true }
+]
+
+
+[tool.poetry.extras]
+testinfra = ["pytest-testinfra"]
 
 [tool.poetry.dev-dependencies]
 black = ">=21.9b0"
@@ -51,6 +56,8 @@ pytest-xdist = ">=2.4.0"
 Sphinx = ">=5.0"
 pytest-rerunfailures = ">=10.2"
 typeguard = ">=2.13"
+ifaddr = "^0.2.0"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest_container/compat.py
+++ b/pytest_container/compat.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING
+
+# mypy will try to import cached_property but fail to find its types
+# since we run mypy with the most recent python version, we can simply import
+# cached_property from stdlib and we'll be fine
+if TYPE_CHECKING:  # pragma: no cover
+    from functools import cached_property
+else:
+    try:
+        from functools import cached_property
+    except ImportError:
+        from cached_property import cached_property
+
+
+__all__ = ["cached_property"]

--- a/pytest_container/pod.py
+++ b/pytest_container/pod.py
@@ -25,7 +25,6 @@ from pytest_container.helpers import get_extra_run_args
 from pytest_container.inspect import PortForwarding
 from pytest_container.logging import _logger
 from pytest_container.runtime import get_selected_runtime
-from pytest_container.runtime import PodmanRuntime
 
 
 @dataclass
@@ -153,9 +152,9 @@ class PodLauncher:
 
     def __enter__(self) -> "PodLauncher":
         runtime = get_selected_runtime()
-        if runtime != PodmanRuntime():
+        if runtime.family != "podman":
             raise RuntimeError(
-                f"pods can only be created with podman, but got {runtime}"
+                f"pods can only be created with podman, but got {runtime.family}"
             )
         return self
 

--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -2,8 +2,7 @@ Prerequisites
 =============
 
 `pytest_container` works with Python 3.6 and later and requires `pytest
-<https://pytest.org/>`_ and `pytest-testinfra
-<https://testinfra.readthedocs.io/>`_. Additionally, for python 3.6, you'll need
+<https://pytest.org/>`_. Additionally, for python 3.6, you'll need
 the `dataclasses <https://pypi.org/project/dataclasses/>`_ module.
 
 Tests leveraging `pytest_container` need to have access to a container

--- a/source/tutorials.rst
+++ b/source/tutorials.rst
@@ -96,7 +96,7 @@ the following test function along with a global variable:
    CONTAINER_IMAGES = [TW_WITH_PKG]
 
    def test_help_works(auto_container):
-       res = auto_container.connection.run_expect([0], "my-binary --help")
+       res = auto_container.remote.check_output("my-binary --help")
        assert "My cool project" in res.stdout
 
 
@@ -108,11 +108,6 @@ executed inside multiple container images, thus avoiding the task of
 parametrizing each of the test manually.
 
 The test function receives a
-:py:class:`~pytest_container.container.ContainerData` instance, where the
-:py:attr:`~pytest_container.container.ContainerData.connection` attribute
-provides a ``testinfra`` connection. The `run_expect
-<https://testinfra.readthedocs.io/en/latest/modules.html#testinfra.host.Host.run_expect>`_
-function is used to execute the binary and check that its exit code is
-``0``. Afterwards, we check that a search string is in the standard output.
+:py:class:`~pytest_container.container.ContainerData` instance.
 
 You can now execute this test via :command:`poetry run pytest`.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,4 +9,5 @@ sphinx
 black
 pylint
 reorder-python-imports
+ifaddr
 .

--- a/tests/test_container_remote.py
+++ b/tests/test_container_remote.py
@@ -1,0 +1,73 @@
+import pytest
+from pytest_container.container import ContainerData
+
+from .images import BUSYBOX
+
+
+@pytest.mark.parametrize("container", [BUSYBOX], indirect=True)
+def test_container_remote_check_output(container: ContainerData) -> None:
+    """
+    Test that `check_output` works as expected.
+    """
+    assert container.remote.check_output("uname") == "Linux"
+
+    # Optionally, don't strip the output
+    assert container.remote.check_output("uname", strip=False) == "Linux\n"
+
+
+@pytest.mark.parametrize("container", [BUSYBOX], indirect=True)
+def test_container_remote_file(container: ContainerData) -> None:
+    """
+    Test that `file` works as expected.
+    """
+
+    # Directory
+    d = container.remote.file("/usr/share/licenses/busybox")
+    assert d.exists
+    assert d.is_directory
+    assert not d.is_file
+    assert d.listdir() == ["LICENSE"]
+    with pytest.raises(
+        ValueError, match="/usr/share/licenses/busybox is a directory"
+    ):
+        d.content_string
+
+    # File
+    f = container.remote.file("/usr/share/licenses/busybox/LICENSE")
+    assert f.exists
+    assert f.is_file
+    assert not f.is_directory
+    assert f.content_string.startswith(
+        """\
+--- A note on GPL versions
+
+BusyBox is distributed under version 2 of the General Public License (included
+in its entirety, below).  Version 2 is the only version of this license which
+this version of BusyBox (or modified versions derived from this one) may be
+distributed under.
+
+------------------------------------------------------------------------
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+"""
+    )
+
+    # Missing file
+    assert not container.remote.file(
+        "/usr/share/licenses/busybox/MISSING"
+    ).exists
+
+
+@pytest.mark.parametrize("container", [BUSYBOX], indirect=True)
+def test_container_remote_copy(container: ContainerData) -> None:
+    """
+    Test that `copy` works as expected.
+    """
+    with open("pyproject.toml", "r", encoding="utf-8") as f:
+        expected_content = f.read()
+
+    f = container.remote.copy("pyproject.toml", "/tmp/pyproject.toml")
+    assert f.path == "/tmp/pyproject.toml"
+    assert f.exists
+    assert f.is_file
+    assert f.content_string == expected_content

--- a/tests/test_copy_from_repo.py
+++ b/tests/test_copy_from_repo.py
@@ -18,10 +18,14 @@ CONTAINER_IMAGES = [LEAP_WITH_CONFIG_FILE]
 def test_config_file_present(
     auto_container: ContainerData, pytestconfig: Config
 ):
-    assert auto_container.connection.file("/opt/app/pyproject.toml").exists
+    assert auto_container.remote.file("/opt/app/pyproject.toml").exists
+
     with open(
         pytestconfig.rootpath / "pyproject.toml", encoding="utf-8"
     ) as pyproject:
-        assert auto_container.connection.file(
-            "/opt/app/pyproject.toml"
-        ).content_string == pyproject.read(-1)
+        expected = pyproject.read(-1)
+
+    assert (
+        expected
+        == auto_container.remote.file("/opt/app/pyproject.toml").content_string
+    )

--- a/tests/test_env_variables.py
+++ b/tests/test_env_variables.py
@@ -16,9 +16,6 @@ CONTAINER_IMAGES = [LEAP_WITH_ENV]
 
 def test_environment_variables_present(auto_container: ContainerData):
     for env_var_name, env_var_val in ENV.items():
-        assert (
-            auto_container.connection.run_expect(
-                [0], f"echo ${env_var_name}"
-            ).stdout.strip()
-            == env_var_val
+        assert env_var_val == auto_container.remote.check_output(
+            f"echo ${env_var_name}"
         )

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -27,7 +27,7 @@ def actual_test(container_data: ContainerData, pytestconf: Config):
     runs in parallel during that time, it would error out.
 
     """
-    container_data.connection.check_output("true")
+    container_data.remote.check_output("true")
     lockfile = pytestconf.rootpath / (
         "leap.lock"
         if "leap" in container_data.image_url_or_id

--- a/tests/test_pytest_param.py
+++ b/tests/test_pytest_param.py
@@ -75,11 +75,11 @@ def test_multistage_build_invalid_param(
     "container_per_test", [container_to_pytest_param(LEAP)], indirect=True
 )
 def test_container_build_with_param(container_per_test: ContainerData):
-    container_per_test.connection.run_expect([0], "true")
+    container_per_test.remote.check_output("true")
 
 
 def test_auto_container_build_with_param(auto_container: ContainerData):
-    auto_container.connection.run_expect([0], "true")
+    auto_container.remote.check_output("true")
 
 
 def test_container_to_pytest_param() -> None:

--- a/tests/test_testinfa.py
+++ b/tests/test_testinfa.py
@@ -1,0 +1,17 @@
+import pytest
+
+try:
+    import testinfra
+except ImportError:
+    raise pytest.skip("testinfra is not installed", allow_module_level=True)
+
+from pytest_container.container import ContainerData
+from .images import BUSYBOX
+
+
+@pytest.mark.parametrize("container", [BUSYBOX], indirect=True)
+def test_testinfra_connection(container: ContainerData):
+
+    assert isinstance(container.connection, testinfra.host.Host)
+    cmd = container.connection.run("ls -l /etc/passwd")
+    assert cmd.rc == 0

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -154,7 +154,7 @@ def test_podman_version_extract(stdout: str, ver: Version):
     assert _get_podman_version(stdout) == ver
 
 
-def test_container_runtime_parsing(host, container_runtime: OciRuntimeBase):
+def test_container_runtime_parsing(container_runtime: OciRuntimeBase):
     """Test that we can recreate the output of
     :command:`$container_runtime_binary --version` from the attribute
     :py:attr:`~pytest_container.runtime.OciRuntimeBase.version`.
@@ -165,18 +165,14 @@ def test_container_runtime_parsing(host, container_runtime: OciRuntimeBase):
         minor=container_runtime.version.minor,
         patch=container_runtime.version.patch,
     )
-    version_string = (
-        host.run_expect([0], f"{container_runtime.runner_binary} --version")
-        .stdout.strip()
-        .lower()
-    )
+    version_string = container_runtime.run_command("--version").lower()
 
     assert (
-        f"{container_runtime.runner_binary} version {version_without_build}"
+        f"{container_runtime.family} version {version_without_build}"
         in version_string
     )
 
-    if container_runtime.runner_binary == "docker":
+    if container_runtime.family == "docker":
         assert f"build {container_runtime.version.build}" in version_string
 
 


### PR DESCRIPTION
**What problem does this solve**

My team is using ``pytest-containers`` for some time now, but we faced a lot of problems trying to get it working on Windows. This is mainly due to ``pytest-testinfra`` not really supporting that platform.

The change aims to make the core functionalities of the project usable on Windows.

**Summary of the changes**

- Changed ``pytest-testinfra`` to an optional dependency installable via ``[testinfra]`` extra
- The test suite now runs on OS X. It didn't because ``host.package()`` is not implement on OS X
- The test suite no longer uses ``host`` to perform local operations. Instead I implemented the minimal set of functions need by the suite in a new ``remote`` attribute.
- Added ``ifaddr`` library as a test dependency for queries available network interfaces. This is not used outside of tests.
- refactored ``get_selected_platform()`` and the runtime classes to not run any shell commands while being imported. The absolute path to the podman/docker command is now resolved lazily and the available platform is selected (following the same podman > docker preference).


